### PR TITLE
feat(i18n): Externalize UI strings for all feature modules

### DIFF
--- a/feature/feature-calendar/src/main/java/presentation/ui/CalenderScreen.kt
+++ b/feature/feature-calendar/src/main/java/presentation/ui/CalenderScreen.kt
@@ -3,11 +3,13 @@ package presentation.ui
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.feature_calendar.R
 
 @Composable
 fun CalendarScreen(modifier: Modifier = Modifier) {
-    Text(modifier = modifier, text = "Calendar Screen")
+    Text(modifier = modifier, text = stringResource(id = R.string.calendar_screen_title))
 }
 
 @Preview

--- a/feature/feature-calendar/src/main/res/values/strings.xml
+++ b/feature/feature-calendar/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="calendar_screen_title">Calendar Screen</string>
+</resources>

--- a/feature/feature-favorites/src/main/java/presentation/ui/FavoritesScreen.kt
+++ b/feature/feature-favorites/src/main/java/presentation/ui/FavoritesScreen.kt
@@ -3,11 +3,13 @@ package presentation.ui
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.feature_favorites.R
 
 @Composable
 fun FavoritesScreen(modifier: Modifier = Modifier) {
-    Text(modifier = modifier, text = "Favorites Screen")
+    Text(modifier = modifier, text = stringResource(id = R.string.favorites_screen_title))
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/feature/feature-favorites/src/main/res/values/strings.xml
+++ b/feature/feature-favorites/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="favorites_screen_title">Favorites Screen</string>
+</resources>

--- a/feature/feature-home/src/main/java/presentation/ui/HomeScreen.kt
+++ b/feature/feature-home/src/main/java/presentation/ui/HomeScreen.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.feature_home.R
 
 @Composable
 fun HomeScreen(modifier: Modifier = Modifier) {
@@ -16,7 +18,7 @@ fun HomeScreen(modifier: Modifier = Modifier) {
     ) {
         Text(
             modifier = Modifier,
-            text = "Home Screen",
+            text = stringResource(id = R.string.home_screen_title),
             style = MaterialTheme.typography.bodyMedium
         )
     }

--- a/feature/feature-home/src/main/res/values/strings.xml
+++ b/feature/feature-home/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="home_screen_title">Home Screen</string>
+</resources>


### PR DESCRIPTION
This commit extends the use of string resource files (`strings.xml`) to all existing feature modules (`feature-calendar`, `feature-favorites`, `feature-home`) to ensure all user-facing text is managed through resources. This follows the earlier internationalization of `feature-login` and `feature-settings`.

Changes include:
- For `feature-calendar`:
    - Created `strings.xml` with `calendar_screen_title`.
    - Updated `CalenderScreen.kt` to use `stringResource()`.
- For `feature-favorites`:
    - Created `strings.xml` with `favorites_screen_title`.
    - Updated `FavoritesScreen.kt` to use `stringResource()`.
- For `feature-home`:
    - Created `strings.xml` with `home_screen_title`.
    - Updated `HomeScreen.kt` to use `stringResource()`.

This effort standardizes string management across the application, improving maintainability and readiness for localization.