### PR TITLE
fix(i18n): Ensure all settings-specific strings are in feature-settin…

### DIFF
--- a/feature/feature-settings/src/main/res/values/strings.xml
+++ b/feature/feature-settings/src/main/res/values/strings.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="settings_login_button_text">Login</string>
+    <string name="settings_language_selection_title">Select Language</string>
+    <string name="settings_language_english">English</string>
+    <string name="settings_language_brazilian_portuguese">Português (Brasil)</string>
+    <string name="settings_content_description_back">Back</string>
+    <string name="settings_language_title">Language</string>
+    <string name="settings_header_account">Account</string>
+    <string name="settings_header_appearance">Appearance</string>
+    <string name="settings_header_actions">Actions</string>
+    <string name="settings_dark_mode_title">Dark Mode</string>
+    <string name="settings_logout_button_title">Logout</string>
+    <string name="settings_login_button_title">Login</string> <!-- Adhering to the list, replacing settings_login_button_text -->
+    <string name="settings_language_description">Select your language</string>
+    <string name="settings_account_information_fallback">Account Information</string>
 </resources>


### PR DESCRIPTION
…gs module

This commit verifies and ensures that all UI strings related to the settings feature are correctly located in `feature-settings/src/main/res/values/strings.xml`.

- Confirmed that `app/src/main/res/values/strings.xml` only contains general application strings (i.e., `app_name`).
- Populated `feature-settings/src/main/res/values/strings.xml` with a comprehensive list of all settings-related strings, including those for language selection, section headers, and actions, to ensure they are not missing from the module.

This resolves any previous discrepancies regarding the location of these string resources.