### PR TITLE
Fix bottom navigation text not updating on language change

### DIFF
--- a/app/src/main/java/com/example/festiveapp/presentation/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/festiveapp/presentation/ui/MainActivity.kt
@@ -97,7 +97,7 @@ class MainActivity : ComponentActivity(), AndroidScopeComponent {
                     if (currentSystemLocale.language != selectedLocale.language ||
                         currentSystemLocale.country != selectedLocale.country) {
                         updateLocale(languageState.currentLanguageCode, this@MainActivity)
-                        // Optional: recreate() // To force resource reloading if necessary
+                        this@MainActivity.recreate() // Force resource reloading
                     }
                 }
             }

--- a/navigation/navigation-ui/src/main/res/values-pt-rBR/strings.xml
+++ b/navigation/navigation-ui/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="navigation_home">Home</string>
+    <string name="navigation_home">Início</string>
     <string name="navigation_settings">Configurações</string>
     <string name="navigation_favorites">Favoritos</string>
     <string name="navigation_events">Eventos</string>


### PR DESCRIPTION
The bottom navigation bar text was not updating after changing the language within the app. This was due to the Activity not being recreated after the locale was programmatically updated.

This commit addresses the issue by:
1. Calling `activity.recreate()` in `MainActivity` after the in-app language selection and locale update. This ensures the Activity and its Compose UI are fully reloaded with the new language configuration.
2. Correcting the Portuguese translation for "Home" in the bottom navigation bar from "Home" to "Início" in the `navigation-ui` module's string resources.

These changes ensure that all text elements, including those in the bottom navigation bar, correctly display the translations for the selected language.