### PR TITLE
feat(settings): Add logout confirmation dialog

### DIFF
--- a/feature/feature-settings/src/main/java/presentation/ui/SettingsScreen.kt
+++ b/feature/feature-settings/src/main/java/presentation/ui/SettingsScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-
+import ui.components.ConfirmationDialog // Added import
 import androidx.compose.ui.res.stringResource // Added
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -83,10 +83,12 @@ fun SettingsScreen(
         themeState = themeState,
         languageState = languageState, // Pass languageState
         onDarkModeChange = appThemeViewModel::onDarkModeChanged,
-        onLogout = settingsViewModel::onLogoutClicked,
         onLogin = settingsViewModel::onLoginClicked,
         onAccountInfoClick = settingsViewModel::onAccountInfoClicked,
-        onLanguageSettingsClicked = onNavigateToLanguageSelection // Use the passed lambda
+        onLanguageSettingsClicked = onNavigateToLanguageSelection, // Use the passed lambda
+        onLogoutRequested = settingsViewModel::onLogoutConfirmationRequested,
+        onLogoutConfirmed = settingsViewModel::onLogoutConfirmed,
+        onLogoutDialogDismissed = settingsViewModel::onLogoutDialogDismissed
     )
 }
 
@@ -96,10 +98,12 @@ fun SettingsContent(
     themeState: AppThemeState,
     languageState: LanguageState, // Added languageState
     onDarkModeChange: (Boolean) -> Unit,
-    onLogout: () -> Unit,
     onLogin: () -> Unit,
     onAccountInfoClick: () -> Unit,
-    onLanguageSettingsClicked: () -> Unit
+    onLanguageSettingsClicked: () -> Unit,
+    onLogoutRequested: () -> Unit,
+    onLogoutConfirmed: () -> Unit,
+    onLogoutDialogDismissed: () -> Unit
 ) {
     val currentLanguageDisplay = when (languageState.currentLanguageCode) {
         "en" -> stringResource(id = R.string.settings_language_english)
@@ -149,7 +153,7 @@ fun SettingsContent(
                     title = stringResource(id = R.string.settings_logout_button_title),
                     icon = Icons.AutoMirrored.Filled.ExitToApp,
                     isDestructive = true,
-                    onClick = onLogout
+                    onClick = onLogoutRequested // Changed to request confirmation
                 )
             )
         } else {
@@ -176,6 +180,19 @@ fun SettingsContent(
                 is ButtonSettingsItem -> ButtonRow(item = item)
             }
         }
+    }
+
+    if (uiState.showLogoutConfirmationDialog) {
+        ui.components.ConfirmationDialog(
+            title = stringResource(id = R.string.settings_logout_dialog_title),
+            message = stringResource(id = R.string.settings_logout_dialog_message),
+            confirmButtonText = stringResource(id = R.string.settings_logout_dialog_confirm_button),
+            denyButtonText = stringResource(id = R.string.settings_logout_dialog_deny_button),
+            onConfirm = onLogoutConfirmed,
+            onDeny = onLogoutDialogDismissed,
+            dismissible = true,
+            onDismissRequest = onLogoutDialogDismissed
+        )
     }
 }
 
@@ -349,10 +366,12 @@ private fun SettingsContentLoggedInPreview() {
             ),
             languageState = LanguageState(),
             onDarkModeChange = {},
-            onLogout = {},
             onLogin = {},
             onAccountInfoClick = {},
-            onLanguageSettingsClicked = {}
+            onLanguageSettingsClicked = {},
+            onLogoutRequested = {},
+            onLogoutConfirmed = {},
+            onLogoutDialogDismissed = {}
         )
     }
 }
@@ -371,10 +390,12 @@ private fun SettingsContentLoggedOutPreview() {
             ),
             languageState = LanguageState(), // Added default state
             onDarkModeChange = {},
-            onLogout = {},
             onLogin = {},
             onAccountInfoClick = {},
-            onLanguageSettingsClicked = {}
+            onLanguageSettingsClicked = {},
+            onLogoutRequested = {},
+            onLogoutConfirmed = {},
+            onLogoutDialogDismissed = {}
         )
     }
 }

--- a/feature/feature-settings/src/main/res/values/strings.xml
+++ b/feature/feature-settings/src/main/res/values/strings.xml
@@ -13,4 +13,9 @@
     <string name="settings_login_button_title">Login</string> <!-- Adhering to the list, replacing settings_login_button_text -->
     <string name="settings_language_description">Select your language</string>
     <string name="settings_account_information_fallback">Account Information</string>
+
+    <string name="settings_logout_dialog_title">Confirm Logout</string>
+    <string name="settings_logout_dialog_message">Are you sure you want to log out?</string>
+    <string name="settings_logout_dialog_confirm_button">Logout</string>
+    <string name="settings_logout_dialog_deny_button">Cancel</string>
 </resources>

--- a/feature/feature-settings/src/test/java/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/feature/feature-settings/src/test/java/presentation/viewmodel/SettingsViewModelTest.kt
@@ -1,0 +1,161 @@
+package presentation.viewmodel
+
+import GenericLogger
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import internal.AppDestination
+import internal.NavigationCommand
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import user.GetUserInfoUseCase
+import user.LogoutUserUseCase
+import user.User // Assuming User is in this package, adjust if needed
+
+@ExperimentalCoroutinesApi
+class SettingsViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var viewModel: SettingsViewModel
+    private lateinit var getUserInfoUseCase: GetUserInfoUseCase
+    private lateinit var logoutUserUseCase: LogoutUserUseCase
+    private lateinit var navigationChannel: Channel<NavigationCommand> // Use a real Channel for testing send/receive
+    private lateinit var logger: GenericLogger
+
+    // Mock User instance for tests
+    private val mockUser = User(userName = "Test User", email = "test@example.com", authToken = "testToken", id = "123")
+
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        getUserInfoUseCase = mockk()
+        logoutUserUseCase = mockk()
+        navigationChannel = Channel<NavigationCommand>(Channel.UNLIMITED) // Use UNLIMITED to avoid suspension on send
+        logger = mockk(relaxed = true) // Relaxed mock for logger as its calls are not critical for these tests
+
+        // Default mock behavior for init block -  ViewModel loads initial settings
+        // Let's assume user is initially logged out for most tests, can be overridden in specific tests
+        coEvery { getUserInfoUseCase() } returns Result.success(null)
+
+        viewModel = SettingsViewModel(
+            getUserInfoUseCase,
+            logoutUserUseCase,
+            navigationChannel,
+            logger
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        navigationChannel.close() // Close the channel after tests
+    }
+
+    @Test
+    fun `onLogoutConfirmationRequested_setsShowDialogToTrue`() = runTest {
+        // Action
+        viewModel.onLogoutConfirmationRequested()
+
+        // Assertion
+        val uiState = viewModel.settingsState.first()
+        assertTrue("showLogoutConfirmationDialog should be true", uiState.showLogoutConfirmationDialog)
+    }
+
+    @Test
+    fun `onLogoutDialogDismissed_setsShowDialogToFalse`() = runTest {
+        // Arrange: ensure dialog is shown first
+        viewModel.onLogoutConfirmationRequested()
+        assertTrue("Pre-condition: showLogoutConfirmationDialog should be true", viewModel.settingsState.first().showLogoutConfirmationDialog)
+
+        // Action
+        viewModel.onLogoutDialogDismissed()
+
+        // Assertion
+        val uiState = viewModel.settingsState.first()
+        assertFalse("showLogoutConfirmationDialog should be false", uiState.showLogoutConfirmationDialog)
+    }
+
+    @Test
+    fun `onLogoutConfirmed_whenLogoutSucceeds_updatesStateAndNavigatesHome`() = runTest(testDispatcher) {
+        // Arrange: User is initially logged in
+        coEvery { getUserInfoUseCase() } returns Result.success(mockUser)
+        // Re-initialize ViewModel to pick up the new mock for getUserInfoUseCase in its init block
+        viewModel = SettingsViewModel(getUserInfoUseCase, logoutUserUseCase, navigationChannel, logger)
+        testDispatcher.scheduler.advanceUntilIdle() // Ensure init completes
+
+        // Ensure initial state is logged in
+        var initialState = viewModel.settingsState.first()
+        assertTrue("Pre-condition: User should be logged in", initialState.isUserLoggedIn)
+        assertEquals("Pre-condition: Username should be set", mockUser.userName, initialState.userName)
+
+        coEvery { logoutUserUseCase() } returns Result.success(Unit)
+
+        // Action
+        viewModel.onLogoutConfirmed()
+        testDispatcher.scheduler.advanceUntilIdle() // Allow coroutines to complete
+
+        // Assertions
+        val uiState = viewModel.settingsState.first()
+        assertFalse("isUserLoggedIn should be false after logout", uiState.isUserLoggedIn)
+        assertNull("userName should be null after logout", uiState.userName)
+        assertNull("userEmail should be null after logout", uiState.userEmail)
+        assertFalse("showLogoutConfirmationDialog should be false", uiState.showLogoutConfirmationDialog)
+
+        // Verify navigation
+        val receivedCommand = navigationChannel.tryReceive().getOrNull()
+        assertEquals("Navigation command should be to Home", AppDestination.Home, (receivedCommand as? NavigationCommand.To)?.destination)
+    }
+
+    @Test
+    fun `onLogoutConfirmed_whenLogoutFails_updatesStateAndDoesNotNavigate`() = runTest(testDispatcher) {
+        // Arrange: User is initially logged in
+        coEvery { getUserInfoUseCase() } returns Result.success(mockUser)
+        // Re-initialize ViewModel to pick up the new mock for getUserInfoUseCase in its init block
+        viewModel = SettingsViewModel(getUserInfoUseCase, logoutUserUseCase, navigationChannel, logger)
+        testDispatcher.scheduler.advanceUntilIdle() // Ensure init completes
+
+        // Ensure initial state is logged in
+        var initialState = viewModel.settingsState.first()
+        assertTrue("Pre-condition: User should be logged in", initialState.isUserLoggedIn)
+        assertEquals("Pre-condition: Username should be set", mockUser.userName, initialState.userName)
+
+
+        coEvery { logoutUserUseCase() } returns Result.failure(Exception("Logout failed"))
+
+        // Action
+        viewModel.onLogoutConfirmed()
+        testDispatcher.scheduler.advanceUntilIdle() // Allow coroutines to complete
+
+        // Assertions
+        val uiState = viewModel.settingsState.first()
+        // User should still be considered logged in if logout failed, or adjust based on actual logic
+        assertTrue("isUserLoggedIn should still be true if logout failed", uiState.isUserLoggedIn)
+        assertEquals("userName should remain if logout failed", mockUser.userName, uiState.userName)
+        assertFalse("showLogoutConfirmationDialog should be false", uiState.showLogoutConfirmationDialog)
+
+        // Verify navigation was not attempted or failed
+        val receivedCommand = navigationChannel.tryReceive().getOrNull()
+        assertNull("Navigation command should be null if logout failed", receivedCommand)
+    }
+}


### PR DESCRIPTION
Implemented a confirmation dialog that appears when you attempt to log out from the Settings screen.

Key changes:
- Modified `SettingsViewModel` to manage the state of the confirmation dialog (show/hide, confirm/deny actions).
- Updated `SettingsScreen` to display a `ConfirmationDialog` composable (from core-ui) when logout is initiated. The dialog prompts you to confirm or cancel the logout action.
- Ensured that if logout is confirmed, you are navigated to the Home screen.
- Added new string resources for the dialog's title, message, and button texts.
- Created `SettingsViewModelTest.kt` with unit tests covering:
    - Dialog visibility logic.
    - Successful logout scenario (state changes, navigation).
    - Failed logout scenario (state changes, no navigation).

The dialog is dismissible by clicking outside, as per your requirements.