### PR TITLE
feat: Initialize app with saved language preference

### DIFF
--- a/app/src/main/java/com/example/festiveapp/preferences/AppPreferencesDataStore.kt
+++ b/app/src/main/java/com/example/festiveapp/preferences/AppPreferencesDataStore.kt
@@ -1,10 +1,44 @@
 package com.example.festiveapp.preferences
 
 import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.firstOrNull
+import preference.AppPreferencesKeys
+import kotlinx.coroutines.flow.map
 
 /**
  * Extension property to provide a DataStore instance for theme preferences.
  * This sets up the DataStore with the specified name "theme_preferences".
  */
 val Context.appThemeDataStore by preferencesDataStore(name = "theme_preferences")
+
+/**
+ * Key for storing the selected language code in DataStore.
+ */
+val SELECTED_LANGUAGE_CODE = stringPreferencesKey(AppPreferencesKeys.KEY_LANGUAGE_CODE)
+
+/**
+ * Retrieves the selected language code from DataStore.
+ *
+ * @param context The application context.
+ * @return The language code string (e.g., "en", "es-ES") or null if not found.
+ */
+suspend fun getSelectedLanguage(context: Context): String? {
+    return context.appThemeDataStore.data.map { preferences ->
+        preferences[SELECTED_LANGUAGE_CODE]
+    }.firstOrNull()
+}
+
+/**
+ * Saves the selected language code to DataStore.
+ *
+ * @param context The application context.
+ * @param languageCode The language code string to save.
+ */
+suspend fun saveSelectedLanguage(context: Context, languageCode: String) {
+    context.appThemeDataStore.edit { preferences ->
+        preferences[SELECTED_LANGUAGE_CODE] = languageCode
+    }
+}

--- a/app/src/main/java/com/example/festiveapp/presentation/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/festiveapp/presentation/ui/MainActivity.kt
@@ -32,6 +32,8 @@ import orchestrator.NavigationOrchestrator
 import org.koin.android.ext.android.getKoin
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.android.ext.android.inject
+import com.example.festiveapp.preferences.getSelectedLanguage
+import kotlinx.coroutines.runBlocking
 import org.koin.android.scope.AndroidScopeComponent
 import org.koin.androidx.compose.koinViewModel
 import org.koin.androidx.scope.activityRetainedScope
@@ -69,6 +71,12 @@ class MainActivity : ComponentActivity(), AndroidScopeComponent {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Retrieve and apply saved language code before setContent
+        val savedLanguageCode = runBlocking { getSelectedLanguage(this@MainActivity.getApplicationContext()) }
+        if (!savedLanguageCode.isNullOrEmpty()) {
+            updateLocale(savedLanguageCode, this@MainActivity.getApplicationContext())
+        }
 
         // Initial locale setup could be considered here if a synchronous way to get
         // the preference on app start was available. DataStore is async, so dynamic

--- a/data/data-repository/src/main/java/preference/UserPreferenceRepositoryImpl.kt
+++ b/data/data-repository/src/main/java/preference/UserPreferenceRepositoryImpl.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import model.LanguagePreference
+import preference.AppPreferencesKeys // Ensure AppPreferencesKeys is imported
 import preference.AppPreferencesKeys.DEFAULT_LANGUAGE_CODE
 import preference.UserPreferenceRepositoryImpl.PreferencesKeys.LANGUAGE_CODE_KEY
 import java.io.IOException
@@ -17,7 +18,8 @@ class UserPreferenceRepositoryImpl(
 ) : UserPreferenceRepository {
 
     private object PreferencesKeys {
-        val LANGUAGE_CODE_KEY = stringPreferencesKey("language_code")
+        // Updated to use the constant from AppPreferencesKeys
+        val LANGUAGE_CODE_KEY = stringPreferencesKey(AppPreferencesKeys.KEY_LANGUAGE_CODE)
     }
 
     override fun getLanguagePreference(): Flow<LanguagePreference> {


### PR DESCRIPTION
I modified the application startup sequence to load and apply the language preference stored in DataStore before the main UI is composed.

Key changes:
- Added `getSelectedLanguage` and `saveSelectedLanguage` to `AppPreferencesDataStore` to directly manage the language code string.
- Updated `MainActivity.onCreate` to call `runBlocking` to fetch the saved language using `getSelectedLanguage` and apply it via `updateLocale` before `setContent`. If no language is saved, the app defaults to the system language.
- Ensured `UserPreferenceRepositoryImpl` and `AppPreferencesDataStore` consistently use the same DataStore key (`AppPreferencesKeys.KEY_LANGUAGE_CODE`) for reading and writing the language preference.
- The existing `LanguageViewModel` and related use cases continue to handle runtime language changes, now benefiting from the consistent key usage.

This ensures that your selected language is applied immediately on app launch, preventing a flicker of the default language.